### PR TITLE
fix(create-months): selected flag should respect year and month

### DIFF
--- a/app/src/pages/home.tsx
+++ b/app/src/pages/home.tsx
@@ -161,7 +161,7 @@ export const HomePage = () => {
         <div className="months">
           {months.map((month) => (
             <button
-              className={getMonthClassName(month.active)}
+              className={getMonthClassName(month.active, month.selected)}
               key={month.name}
               {...monthButton(month)}
             >
@@ -190,7 +190,7 @@ export const HomePage = () => {
         <div className="years">
           {years.map((year) => (
             <button
-              className={getYearsClassName(year.active)}
+              className={getYearsClassName(year.active, year.selected)}
               key={year.value}
               {...yearButton(year)}
             >

--- a/app/src/pages/modular-context.tsx
+++ b/app/src/pages/modular-context.tsx
@@ -75,7 +75,7 @@ export const ModularContext = () => {
         <div className="months">
           {months.map((month) => (
             <button
-              className={getMonthClassName(month.active)}
+              className={getMonthClassName(month.active, month.selected)}
               key={month.name}
               {...monthButton(month)}
             >
@@ -104,7 +104,7 @@ export const ModularContext = () => {
         <div className="years">
           {years.map((year) => (
             <button
-              className={getYearsClassName(year.active)}
+              className={getYearsClassName(year.active, year.selected)}
               key={year.value}
               {...yearButton(year)}
             >

--- a/app/src/styles/calendar.css
+++ b/app/src/styles/calendar.css
@@ -152,6 +152,11 @@ button.day.secondary {
   background-color: var(--selected-range);
 }
 
+.month.selected,
+.year.selected {
+  background-color: var(--selected-day);
+}
+
 button.day:disabled,
 button.month:disabled,
 button.year:disabled,

--- a/app/src/utils/class-names.ts
+++ b/app/src/utils/class-names.ts
@@ -16,6 +16,8 @@ export const getDayClassName = (
     ...classNames,
   );
 
-export const getMonthClassName = (active: boolean) => clsx('month', { active });
+export const getMonthClassName = (active: boolean, selected: boolean) =>
+  clsx('month', { active, selected });
 
-export const getYearsClassName = (active: boolean) => clsx('year', { active });
+export const getYearsClassName = (active: boolean, selected: boolean) =>
+  clsx('year', { active, selected });

--- a/src/__test__/create-month.test.ts
+++ b/src/__test__/create-month.test.ts
@@ -6,7 +6,12 @@ import { TEST_MONTHS } from '../__mock__/months';
 describe('createMonth', () => {
   test('createMonth should generate months correctly', () => {
     const { locale, dates } = createConfig();
-    const months = createMonths(new Date(2022, 10, 20), [], locale, dates);
+    const months = createMonths(
+      new Date(2022, 10, 20),
+      [new Date(2021, 6, 4)],
+      locale,
+      dates,
+    );
 
     expect(months).toEqual(TEST_MONTHS);
   });

--- a/src/utils/create-months.ts
+++ b/src/utils/create-months.ts
@@ -19,7 +19,10 @@ export const createMonths = (
     months.push({
       $date: date,
       name: formatMonthName(date, locale),
-      selected: selectedDates.some((d) => getDateParts(d).M === i),
+      selected: selectedDates.some((d) => {
+        const { M: dM, Y: dY } = getDateParts(d);
+        return dY === Y && dM === i;
+      }),
       active: M === i,
       disabled:
         minDateAndBeforeFirstDay(minDate, date) ||


### PR DESCRIPTION

Hi, thank you for you great work. 
I found small issue that probably was missed.
By docs month have a selected flag:
> selected - shaws that we have a date selected for this month.

In current realisation selected month is true in every year, because flag takes in account only month, but not year.

This is how it looks in app:
<img width="782" alt="Screenshot 2023-01-25 at 14 57 27" src="https://user-images.githubusercontent.com/18456914/214524719-6d5142a5-a771-40a7-a3c4-11b3df692f27.png">
I select a date in the October 2022, but current year is 2020 and October is marked as selected.

This is how I expect it should work:
<img width="782" alt="Screenshot 2023-01-25 at 15 00 08" src="https://user-images.githubusercontent.com/18456914/214525229-29614ab6-61ea-4389-a8cf-920483a44043.png">

## Checklist

- [ x] My code follows the style guidelines of this project
- [ x] I have performed a self-review of my own code
- [ x] My changes generate no new warnings
- [ x] I have added tests that prove my fix is effective or that my feature works
- [ x] New and existing tests pass locally with my changes
