### PR TITLE
v6.0.0 external offsetDate

### DIFF
--- a/app/src/model/modular-context-provider.tsx
+++ b/app/src/model/modular-context-provider.tsx
@@ -1,29 +1,28 @@
-import {
-  DatePickerStateProvider,
-  DatePickerUserConfig,
-} from '@rehookify/datepicker';
+import { DatePickerStateProvider } from '@rehookify/datepicker';
 import React, { useState } from 'react';
 import { Outlet } from 'react-router-dom';
 
 export const ModularContextProvider = () => {
   const [selectedDates, onDatesChange] = useState<Date[]>([]);
-  const config: DatePickerUserConfig = {
-    selectedDates,
-    onDatesChange,
-    dates: {
-      mode: 'multiple',
-    },
-    calendar: {
-      startDay: 1,
-      mode: 'fluid',
-    },
-    exclude: {
-      day: [0, 6],
-      date: [new Date(2023, 2, 8)],
-    },
-  };
+
   return (
-    <DatePickerStateProvider config={config}>
+    <DatePickerStateProvider
+      config={{
+        selectedDates,
+        onDatesChange,
+        dates: {
+          mode: 'multiple',
+        },
+        calendar: {
+          startDay: 1,
+          // mode: 'fluid',
+        },
+        exclude: {
+          // day: [0, 6],
+          // date: [new Date(2023, 2, 8)],
+        },
+      }}
+    >
       <Outlet />
     </DatePickerStateProvider>
   );

--- a/app/src/model/modular-context-provider.tsx
+++ b/app/src/model/modular-context-provider.tsx
@@ -11,7 +11,7 @@ export const ModularContextProvider = () => {
         selectedDates,
         onDatesChange,
         dates: {
-          mode: 'multiple',
+          // mode: 'multiple',
         },
         calendar: {
           startDay: 1,

--- a/app/src/pages/home.tsx
+++ b/app/src/pages/home.tsx
@@ -45,8 +45,8 @@ export const HomePage = () => {
     data: { calendars, weekDays, months, years },
     propGetters: {
       dayButton,
-      addOffset,
-      subtractOffset,
+      previousMonthButton,
+      nextMonthButton,
       monthButton,
       yearButton,
       nextYearsButton,
@@ -73,7 +73,7 @@ export const HomePage = () => {
         <CalendarHeader
           leftButton={
             <HeaderButton
-              {...subtractOffset({ months: 1 })}
+              {...previousMonthButton()}
               data-testid="previous-month-button"
             >
               <ChevronLeft />
@@ -121,7 +121,7 @@ export const HomePage = () => {
         <CalendarHeader
           rightButton={
             <HeaderButton
-              {...addOffset({ months: 1 })}
+              {...nextMonthButton()}
               data-testid="next-month-button"
             >
               <ChevronRight />
@@ -149,12 +149,12 @@ export const HomePage = () => {
       <Calendar>
         <CalendarHeader
           leftButton={
-            <HeaderButton {...subtractOffset({ months: 1 })}>
+            <HeaderButton {...previousMonthButton()}>
               <ChevronLeft />
             </HeaderButton>
           }
           rightButton={
-            <HeaderButton {...addOffset({ months: 1 })}>
+            <HeaderButton {...nextMonthButton()}>
               <ChevronRight />
             </HeaderButton>
           }

--- a/app/src/pages/home.tsx
+++ b/app/src/pages/home.tsx
@@ -45,8 +45,8 @@ export const HomePage = () => {
     data: { calendars, weekDays, months, years },
     propGetters: {
       dayButton,
-      previousMonthButton,
-      nextMonthButton,
+      addOffset,
+      subtractOffset,
       monthButton,
       yearButton,
       nextYearsButton,
@@ -73,7 +73,7 @@ export const HomePage = () => {
         <CalendarHeader
           leftButton={
             <HeaderButton
-              {...previousMonthButton()}
+              {...subtractOffset({ months: 1 })}
               data-testid="previous-month-button"
             >
               <ChevronLeft />
@@ -121,7 +121,7 @@ export const HomePage = () => {
         <CalendarHeader
           rightButton={
             <HeaderButton
-              {...nextMonthButton()}
+              {...addOffset({ months: 1 })}
               data-testid="next-month-button"
             >
               <ChevronRight />
@@ -149,12 +149,12 @@ export const HomePage = () => {
       <Calendar>
         <CalendarHeader
           leftButton={
-            <HeaderButton {...previousMonthButton()}>
+            <HeaderButton {...subtractOffset({ months: 1 })}>
               <ChevronLeft />
             </HeaderButton>
           }
           rightButton={
-            <HeaderButton {...nextMonthButton()}>
+            <HeaderButton {...addOffset({ months: 1 })}>
               <ChevronRight />
             </HeaderButton>
           }

--- a/app/src/pages/modular-context.tsx
+++ b/app/src/pages/modular-context.tsx
@@ -1,5 +1,6 @@
 import {
   useContextCalendars,
+  useContextDatePickerOffsetPropGetters,
   useContextDaysPropGetters,
   useContextMonths,
   useContextMonthsPropGetters,
@@ -32,8 +33,8 @@ export const ModularContext = () => {
   const { calendars, weekDays } = useContextCalendars();
   const { dayButton } = useContextDaysPropGetters();
   const { months } = useContextMonths();
-  const { previousMonthButton, nextMonthButton, monthButton } =
-    useContextMonthsPropGetters();
+  const { monthButton } = useContextMonthsPropGetters();
+  const { addOffset, subtractOffset } = useContextDatePickerOffsetPropGetters();
   const { years } = useContextYears();
   const { previousYearsButton, nextYearsButton, yearButton } =
     useContextYearsPropGetters();
@@ -66,12 +67,12 @@ export const ModularContext = () => {
       <Calendar>
         <CalendarHeader
           leftButton={
-            <HeaderButton {...previousMonthButton()}>
+            <HeaderButton {...subtractOffset({ months: 1 })}>
               <ChevronLeft />
             </HeaderButton>
           }
           rightButton={
-            <HeaderButton {...nextMonthButton()}>
+            <HeaderButton {...addOffset({ months: 1 })}>
               <ChevronRight />
             </HeaderButton>
           }

--- a/app/src/pages/modular-context.tsx
+++ b/app/src/pages/modular-context.tsx
@@ -1,6 +1,5 @@
 import {
   useContextCalendars,
-  useContextDatePickerOffsetPropGetters,
   useContextDaysPropGetters,
   useContextMonths,
   useContextMonthsPropGetters,
@@ -33,8 +32,8 @@ export const ModularContext = () => {
   const { calendars, weekDays } = useContextCalendars();
   const { dayButton } = useContextDaysPropGetters();
   const { months } = useContextMonths();
-  const { monthButton } = useContextMonthsPropGetters();
-  const { addOffset, subtractOffset } = useContextDatePickerOffsetPropGetters();
+  const { previousMonthButton, nextMonthButton, monthButton } =
+    useContextMonthsPropGetters();
   const { years } = useContextYears();
   const { previousYearsButton, nextYearsButton, yearButton } =
     useContextYearsPropGetters();
@@ -67,12 +66,12 @@ export const ModularContext = () => {
       <Calendar>
         <CalendarHeader
           leftButton={
-            <HeaderButton {...subtractOffset({ months: 1 })}>
+            <HeaderButton {...previousMonthButton()}>
               <ChevronLeft />
             </HeaderButton>
           }
           rightButton={
-            <HeaderButton {...addOffset({ months: 1 })}>
+            <HeaderButton {...nextMonthButton()}>
               <ChevronRight />
             </HeaderButton>
           }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rehookify/datepicker",
-  "version": "5.2.2",
+  "version": "6.0.0",
   "description": "The ultimate tool to create a date, range and time picker in your React applications.",
   "main": "dist/index.cjs.js",
   "module": "dist/index.esm.mjs",
@@ -29,7 +29,7 @@
     "lint:fix": "eslint src/ --fix",
     "prebuild": "npm run clean",
     "prepare": "husky install",
-    "prepublishOnly": "npm run test && npm run clean && npm run build",
+    "prepublishOnly": "npm t --run && npm run clean && npm run build",
     "test": "vitest",
     "t:e2e": "playwright test",
     "start:app": "npm start --prefix ./app",
@@ -98,7 +98,8 @@
   },
   "lint-staged": {
     "**/*.{ts,tsx}": [
-      "npm run lint:fix"
+      "prettier --write",
+      "eslint --fix"
     ]
   },
   "publishConfig": {

--- a/src/__mock__/config.ts
+++ b/src/__mock__/config.ts
@@ -1,6 +1,9 @@
+import { vi } from 'vitest';
+
 export const DEFAULT_CONFIG = {
   selectedDates: [],
-  focusDate: null,
+  onDatesChange: vi.fn,
+  focusDate: undefined,
   calendar: {
     mode: 'static',
     offsets: [0],

--- a/src/__mock__/initial-state.ts
+++ b/src/__mock__/initial-state.ts
@@ -1,11 +1,16 @@
+import { vi } from 'vitest';
+
 import { createConfig } from '../utils/config';
 import { getCleanDate, getDateParts, newDate } from '../utils/date';
 import { getCurrentYearPosition } from '../utils/get-current-year-position';
 
-const config = createConfig({});
+const config = createConfig({
+  selectedDates: [],
+  onDatesChange: vi.fn(),
+});
 
 export const INITIAL_STATE = {
-  focusDate: null,
+  focusDate: undefined,
   rangeEnd: null,
   offsetDate: getCleanDate(newDate()),
   offsetYear: getCurrentYearPosition(

--- a/src/__test__/config.test.ts
+++ b/src/__test__/config.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test } from 'vitest';
+import { describe, expect, test, vi } from 'vitest';
 
 import { DEFAULT_CONFIG } from '../__mock__/config';
 import { ALTERNATIVE_LOCALE_CONFIG } from '../__mock__/locale';
@@ -8,11 +8,16 @@ import { isBefore } from '../utils/predicates';
 
 describe('createConfig', () => {
   test('should create correct default config', () => {
-    expect(createConfig()).toEqual(DEFAULT_CONFIG);
+    // vi.fn here because we can't assert over vi.fn() because resolves based on context
+    expect(createConfig({ selectedDates: [], onDatesChange: vi.fn })).toEqual(
+      DEFAULT_CONFIG,
+    );
   });
 
   test('correctly composes calendar config', () => {
     const { calendar } = createConfig({
+      selectedDates: [],
+      onDatesChange: vi.fn(),
       calendar: { mode: 'fluid', offsets: [1] },
     });
 
@@ -22,6 +27,8 @@ describe('createConfig', () => {
 
   test('correctly creates years', () => {
     const { years } = createConfig({
+      selectedDates: [],
+      onDatesChange: vi.fn(),
       years: { numberOfYears: 100 },
     });
 
@@ -33,6 +40,7 @@ describe('createConfig', () => {
     const { Y, M } = getDateParts(d);
     const { dates, selectedDates } = createConfig({
       selectedDates: [d],
+      onDatesChange: vi.fn(),
       dates: {
         mode: 'multiple',
         toggle: true,
@@ -52,6 +60,8 @@ describe('createConfig', () => {
 
   test('correctly composes locales', () => {
     const { locale } = createConfig({
+      selectedDates: [],
+      onDatesChange: vi.fn(),
       locale: ALTERNATIVE_LOCALE_CONFIG,
     });
 
@@ -62,6 +72,8 @@ describe('createConfig', () => {
     const d = newDate();
     const { Y, M, D } = getDateParts(d);
     const { dates } = createConfig({
+      selectedDates: [],
+      onDatesChange: vi.fn(),
       dates: {
         minDate: newDate(Y, M + 1, D),
         maxDate: newDate(Y, M - 1, D),
@@ -76,25 +88,41 @@ describe('createConfig', () => {
   test('should respect min and max time', () => {
     const minTime = { h: 9, m: 11 };
     const maxTime = { h: 16, m: 0 };
-    const c1 = createConfig({ time: { minTime } });
+    const c1 = createConfig({
+      selectedDates: [],
+      onDatesChange: vi.fn(),
+      time: { minTime },
+    });
 
     // minTime should remain as is because we don't have maxTime
     expect(c1.time.minTime).toEqual(minTime);
     expect(c1.time.maxTime).toBe(undefined);
 
-    const c2 = createConfig({ time: { maxTime } });
+    const c2 = createConfig({
+      selectedDates: [],
+      onDatesChange: vi.fn(),
+      time: { maxTime },
+    });
 
     // maxTime should remain as is because we don't have minTime
     expect(c2.time.minTime).toBe(undefined);
     expect(c2.time.maxTime).toEqual(maxTime);
 
-    const c3 = createConfig({ time: { minTime: maxTime, maxTime: minTime } });
+    const c3 = createConfig({
+      selectedDates: [],
+      onDatesChange: vi.fn(),
+      time: { minTime: maxTime, maxTime: minTime },
+    });
 
     // We should swap min and max because minTime > maxTime
     expect(c3.time.minTime).toEqual(minTime);
     expect(c3.time.maxTime).toEqual(maxTime);
 
-    const c4 = createConfig({ time: { minTime, maxTime } });
+    const c4 = createConfig({
+      selectedDates: [],
+      onDatesChange: vi.fn(),
+      time: { minTime, maxTime },
+    });
 
     // minTime and maxTime should stay as is
     expect(c4.time.minTime).toEqual(minTime);
@@ -104,11 +132,19 @@ describe('createConfig', () => {
   test('should set focusTime if it is present in selectedDates', () => {
     const d1 = getCleanDate(newDate());
     const d2 = newDate(d1.setDate(33));
-    const c1 = createConfig({ selectedDates: [d1], focusDate: d2 });
+    const c1 = createConfig({
+      selectedDates: [d1],
+      onDatesChange: vi.fn(),
+      focusDate: d2,
+    });
 
-    expect(c1.focusDate).toBeNull();
+    expect(c1.focusDate).toBe(undefined);
 
-    const c2 = createConfig({ selectedDates: [d1, d2], focusDate: d1 });
+    const c2 = createConfig({
+      selectedDates: [d1, d2],
+      onDatesChange: vi.fn(),
+      focusDate: d1,
+    });
 
     expect(c2.focusDate).toEqual(d1);
   });

--- a/src/__test__/create-calendars.test.ts
+++ b/src/__test__/create-calendars.test.ts
@@ -8,7 +8,10 @@ import { getCleanDate, newDate } from '../utils/date';
 describe('createCalendars', () => {
   test('createCalendars should create a calendar correctly with default configuration', () => {
     const now = getCleanDate(newDate());
-    const config = createConfig();
+    const config = createConfig({
+      selectedDates: [now],
+      onDatesChange: vi.fn(),
+    });
     const state = createInitialState(config);
 
     const testCalendar = createCalendars({
@@ -16,6 +19,7 @@ describe('createCalendars', () => {
       state,
       config,
       dispatch: vi.fn(),
+      offsetDate: newDate(),
     });
     const { days } = testCalendar[0];
 
@@ -31,6 +35,7 @@ describe('createCalendars', () => {
     const offsetDate = getCleanDate(newDate(2022, 10, 20));
     const config = createConfig({
       selectedDates: [offsetDate],
+      onDatesChange: vi.fn(),
       calendar: { offsets: [-1, 1] },
     });
     const state = createInitialState(config);
@@ -40,6 +45,7 @@ describe('createCalendars', () => {
       state,
       config,
       dispatch: vi.fn(),
+      offsetDate,
     });
 
     expect(testCalendar.length).toBe(3);
@@ -52,6 +58,7 @@ describe('createCalendars', () => {
     const offsetDate = getCleanDate(newDate(2022, 10, 20));
     const config = createConfig({
       selectedDates: [offsetDate],
+      onDatesChange: vi.fn(),
       calendar: { mode: 'fluid' },
     });
 
@@ -62,6 +69,7 @@ describe('createCalendars', () => {
       state,
       config,
       dispatch: vi.fn(),
+      offsetDate,
     });
 
     expect(testCalendar.days.length).toBe(35);

--- a/src/__test__/create-initial-state.test.ts
+++ b/src/__test__/create-initial-state.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test } from 'vitest';
+import { describe, expect, test, vi } from 'vitest';
 
 import { INITIAL_STATE } from '../__mock__/initial-state';
 import { createConfig } from '../utils/config';
@@ -6,7 +6,10 @@ import { createInitialState } from '../utils/create-initial-state';
 
 describe('createInitialState', () => {
   test('createInitialState should create correct state', () => {
-    const config = createConfig({});
+    const config = createConfig({
+      selectedDates: [],
+      onDatesChange: vi.fn(),
+    });
     const state = createInitialState(config);
 
     expect(state).toEqual(INITIAL_STATE);

--- a/src/__test__/create-month.test.ts
+++ b/src/__test__/create-month.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test } from 'vitest';
+import { describe, expect, test, vi } from 'vitest';
 
 import { createConfig } from '../utils/config';
 import { createMonths } from '../utils/create-months';
@@ -6,7 +6,10 @@ import { getCleanDate, getDateParts, newDate } from '../utils/date';
 
 describe('createMonth', () => {
   test('createMonth should generate months correctly', () => {
-    const { locale, dates } = createConfig();
+    const { locale, dates } = createConfig({
+      selectedDates: [],
+      onDatesChange: vi.fn(),
+    });
 
     // Default configuration with no selected dates
     const NOW = getCleanDate(newDate());

--- a/src/__test__/create-time.test.ts
+++ b/src/__test__/create-time.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test } from 'vitest';
+import { describe, expect, test, vi } from 'vitest';
 
 import { createConfig } from '../utils/config';
 import { createTime } from '../utils/create-time';
@@ -6,15 +6,22 @@ import { newDate } from '../utils/date';
 
 describe('createTime', () => {
   test('should generate times correctly', () => {
-    const config = createConfig();
-    const time = createTime(null, config);
+    const config = createConfig({
+      selectedDates: [],
+      onDatesChange: vi.fn(),
+    });
+    const time = createTime(undefined, config);
 
     // If we will not provide date all buttons should be disabled
     expect(time.filter(({ disabled }) => disabled).length).toBe(time.length);
     // The default interval is 30 so we have 2 segments for 1 hour
     expect(time.length).toBe(48);
 
-    const config2 = createConfig({ time: { interval: 60 } });
+    const config2 = createConfig({
+      selectedDates: [],
+      onDatesChange: vi.fn(),
+      time: { interval: 60 },
+    });
     const time2 = createTime(newDate(), config2);
 
     expect(time2.filter(({ disabled }) => disabled).length).toBe(0);
@@ -25,6 +32,8 @@ describe('createTime', () => {
   test('should create times correctly with min and max dates', () => {
     const d = newDate();
     const config = createConfig({
+      selectedDates: [],
+      onDatesChange: vi.fn(),
       time: { minTime: { h: 9, m: 0 }, maxTime: { h: 18, m: 0 } },
     });
     const time = createTime(d, config);

--- a/src/__test__/create-weekdays.test.ts
+++ b/src/__test__/create-weekdays.test.ts
@@ -8,7 +8,10 @@ import { createWeekdays } from '../utils/create-weekdays';
 import { getCleanDate, newDate } from '../utils/date';
 
 const now = getCleanDate(newDate());
-const config = createConfig();
+const config = createConfig({
+  selectedDates: [now],
+  onDatesChange: vi.fn(),
+});
 const state = createInitialState(config);
 
 const TEST_CALENDAR = createCalendars({
@@ -16,6 +19,7 @@ const TEST_CALENDAR = createCalendars({
   state,
   config,
   dispatch: vi.fn(),
+  offsetDate: newDate(),
 })[0];
 
 describe('createWeekdays', () => {
@@ -27,7 +31,11 @@ describe('createWeekdays', () => {
   });
 
   test('createWeekdays create weekdays correctly with alternative locale', () => {
-    const config = createConfig({ locale: ALTERNATIVE_LOCALE_CONFIG });
+    const config = createConfig({
+      selectedDates: [],
+      onDatesChange: vi.fn(),
+      locale: ALTERNATIVE_LOCALE_CONFIG,
+    });
     const weekdays = createWeekdays(TEST_CALENDAR, config);
 
     // Weekdays with Ukrainian locale and weekdays = 'short'

--- a/src/__test__/create-years.test.ts
+++ b/src/__test__/create-years.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test } from 'vitest';
+import { describe, expect, test, vi } from 'vitest';
 
 import { createConfig } from '../utils/config';
 import { createYears } from '../utils/create-years';
@@ -7,7 +7,10 @@ import { getStartDecadePosition } from '../utils/get-current-year-position';
 
 describe('createYears', () => {
   test('createYears should create years correctly', () => {
-    const { years: yearsConfig, dates } = createConfig();
+    const { years: yearsConfig, dates } = createConfig({
+      selectedDates: [],
+      onDatesChange: vi.fn(),
+    });
     const NOW = newDate();
     const { Y, M, D } = getDateParts(NOW);
 
@@ -57,6 +60,8 @@ describe('createYears', () => {
 
   test('createYears should generate correct number of years', () => {
     const { years: yearsConfig, dates } = createConfig({
+      selectedDates: [],
+      onDatesChange: vi.fn(),
       years: {
         numberOfYears: 50,
       },

--- a/src/__test__/excluded.test.ts
+++ b/src/__test__/excluded.test.ts
@@ -11,6 +11,8 @@ describe('isExcludedDay', () => {
     // exclude all Sundays
     const EXCLUDED_DATE = 0;
     const config = createConfig({
+      selectedDates: [],
+      onDatesChange: vi.fn(),
       exclude: {
         day: [EXCLUDED_DATE],
       },
@@ -22,6 +24,7 @@ describe('isExcludedDay', () => {
       state,
       config,
       dispatch: vi.fn(),
+      offsetDate: newDate(),
     });
     const { days } = calendar;
 
@@ -37,6 +40,8 @@ describe('isExcludedDate', () => {
   test('should exclude dates', () => {
     const NOW = getCleanDate(newDate());
     const config = createConfig({
+      selectedDates: [],
+      onDatesChange: vi.fn(),
       exclude: {
         date: [NOW],
       },
@@ -48,6 +53,7 @@ describe('isExcludedDate', () => {
       state,
       config,
       dispatch: vi.fn(),
+      offsetDate: newDate(),
     });
     const { days } = calendar;
 

--- a/src/__test__/get-calendar-month-params.test.ts
+++ b/src/__test__/get-calendar-month-params.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test } from 'vitest';
+import { describe, expect, test, vi } from 'vitest';
 
 import { createConfig } from '../utils/config';
 import { getDateParts, newDate } from '../utils/date';
@@ -8,7 +8,11 @@ describe('getCalendarMonthParams', () => {
   const { Y, M } = getDateParts(newDate(2023, 0, 1));
 
   test('should return correct data in static mode', () => {
-    const config = createConfig({ calendar: { mode: 'static' } });
+    const config = createConfig({
+      selectedDates: [],
+      onDatesChange: vi.fn(),
+      calendar: { mode: 'static' },
+    });
     expect(getCalendarMonthParams(M, Y, config.calendar)).toEqual({
       start: 0,
       length: 42,
@@ -16,7 +20,11 @@ describe('getCalendarMonthParams', () => {
   });
 
   test('getCalendarMonthParams should return correct data in fluid mode', () => {
-    const config = createConfig({ calendar: { mode: 'fluid' } });
+    const config = createConfig({
+      selectedDates: [],
+      onDatesChange: vi.fn(),
+      calendar: { mode: 'fluid' },
+    });
     expect(getCalendarMonthParams(M, Y, config.calendar)).toEqual({
       start: 0,
       length: 35,

--- a/src/__test__/get-multiple-dates.test.ts
+++ b/src/__test__/get-multiple-dates.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test } from 'vitest';
+import { describe, expect, test, vi } from 'vitest';
 
 import { createConfig } from '../utils/config';
 import { newDate } from '../utils/date';
@@ -6,7 +6,10 @@ import { getMultipleDates } from '../utils/get-multiple-dates';
 
 describe('getMultipleDates', () => {
   test('returns correct data in single mode', () => {
-    const { dates } = createConfig();
+    const { dates } = createConfig({
+      selectedDates: [],
+      onDatesChange: vi.fn(),
+    });
 
     // Adds date correctly
     const clickedDate = newDate(2022, 10, 21);
@@ -19,6 +22,8 @@ describe('getMultipleDates', () => {
 
   test('returns correct data in multiple mode', () => {
     const { dates } = createConfig({
+      selectedDates: [],
+      onDatesChange: vi.fn(),
       dates: { mode: 'multiple', toggle: true, limit: 3 },
     });
 
@@ -46,6 +51,8 @@ describe('getMultipleDates', () => {
 
   test('returns correct data in range mode', () => {
     const { dates } = createConfig({
+      selectedDates: [],
+      onDatesChange: vi.fn(),
       dates: { mode: 'range', toggle: true },
     });
     const clickedDate = newDate(2022, 10, 21);

--- a/src/__test__/offset.test.ts
+++ b/src/__test__/offset.test.ts
@@ -1,0 +1,83 @@
+import { act, renderHook } from '@testing-library/react';
+import { useState } from 'react';
+import { describe, expect, test, vi } from 'vitest';
+
+import { useDatePickerState } from '../use-date-picker-state';
+import { getCleanDate, newDate } from '../utils/date';
+import { getNextOffsetDate, setDPOffset } from '../utils/offset';
+
+describe('setDPOffset', () => {
+  test('should set offset without onOffsetChange', () => {
+    const d = getCleanDate(newDate(2022, 11, 11));
+    const { result } = renderHook(() =>
+      useDatePickerState({
+        selectedDates: [],
+        onDatesChange: vi.fn(),
+      }),
+    );
+
+    act(() => setDPOffset(result.current)(d)),
+      expect(result.current.offsetDate).toEqual(d);
+  });
+
+  test('should set offset with onOffsetChange', () => {
+    const d = getCleanDate(newDate(2022, 11, 11));
+    const d1 = newDate();
+    const { result: offsetResult } = renderHook(() => useState(d1));
+    const { result } = renderHook(() =>
+      useDatePickerState({
+        selectedDates: [],
+        onDatesChange: vi.fn(),
+        offsetDate: offsetResult.current[0],
+        onOffsetChange: offsetResult.current[1],
+      }),
+    );
+
+    act(() => setDPOffset(result.current)(d));
+
+    expect(offsetResult.current[0]).toEqual(d);
+    expect(result.current.offsetDate).toEqual(d1);
+  });
+});
+
+describe('getNextOffsetDate', () => {
+  test('should add offset correctly', () => {
+    const d = getCleanDate(newDate(2022, 11, 11));
+
+    const testResult1 = getNextOffsetDate(d, { days: 21, months: 0, years: 0 });
+    expect(testResult1).toEqual(getCleanDate(newDate(2023, 0, 1)));
+
+    const testResult2 = getNextOffsetDate(d, { days: 0, months: 1, years: 0 });
+    expect(testResult2).toEqual(getCleanDate(newDate(2023, 0, 11)));
+
+    const testResult3 = getNextOffsetDate(d, { days: 0, months: 0, years: 1 });
+    expect(testResult3).toEqual(getCleanDate(newDate(2023, 11, 11)));
+
+    const testResult4 = getNextOffsetDate(d, { days: 1, months: 1, years: 1 });
+    expect(testResult4).toEqual(getCleanDate(newDate(2024, 0, 12)));
+  });
+
+  test('should subtract offset correctly', () => {
+    const d = getCleanDate(newDate(2022, 11, 11));
+
+    const testResult1 = getNextOffsetDate(d, {
+      days: -11,
+      months: 0,
+      years: 0,
+    });
+    expect(testResult1).toEqual(getCleanDate(newDate(2022, 10, 30)));
+
+    const testResult2 = getNextOffsetDate(d, { days: 0, months: -1, years: 0 });
+    expect(testResult2).toEqual(getCleanDate(newDate(2022, 10, 11)));
+
+    const testResult3 = getNextOffsetDate(d, { days: 0, months: 0, years: -1 });
+    expect(testResult3).toEqual(getCleanDate(newDate(2021, 11, 11)));
+
+    const testResult4 = getNextOffsetDate(d, {
+      days: -11,
+      months: -11,
+      years: -1,
+    });
+    expect(testResult4).toEqual(getCleanDate(newDate(2020, 11, 30)));
+  });
+});

--- a/src/__test__/use-calendars.test.ts
+++ b/src/__test__/use-calendars.test.ts
@@ -1,5 +1,5 @@
 import { renderHook } from '@testing-library/react';
-import { describe, expect, test } from 'vitest';
+import { describe, expect, test, vi } from 'vitest';
 
 import { useCalendars } from '../use-calendars';
 import { useDatePickerState } from '../use-date-picker-state';
@@ -8,7 +8,9 @@ import { createWeekdays } from '../utils/create-weekdays';
 
 describe('useCalendars', () => {
   test('useCalendars should return correct calendars and weekDays', () => {
-    const { result: stateResult } = renderHook(() => useDatePickerState());
+    const { result: stateResult } = renderHook(() =>
+      useDatePickerState({ selectedDates: [], onDatesChange: vi.fn() }),
+    );
     const { result } = renderHook(() => useCalendars(stateResult.current));
 
     const calendars = createCalendars(stateResult.current);

--- a/src/__test__/use-date-picker-offset.test.ts
+++ b/src/__test__/use-date-picker-offset.test.ts
@@ -1,0 +1,74 @@
+import { act, renderHook } from '@testing-library/react';
+import { useState } from 'react';
+import { describe, expect, test, vi } from 'vitest';
+
+import { useDatePickerOffsetPropGetters } from '../use-date-picker-offset';
+import { useDatePickerState } from '../use-date-picker-state';
+import { newDate } from '../utils/date';
+
+describe('useDatePickerOffsetPropGetters', () => {
+  test('setOffset: should set correct offsetDate', () => {
+    const { result: sResult } = renderHook(() =>
+      useDatePickerState({ selectedDates: [], onDatesChange: vi.fn() }),
+    );
+    const { result: oResult } = renderHook(() =>
+      useDatePickerOffsetPropGetters(sResult.current),
+    );
+
+    const nextDate = newDate(2020, 1, 1);
+    const { onClick } = oResult.current.setOffset(nextDate);
+
+    // @ts-ignore-next-line
+    act(() => onClick(nextDate));
+
+    expect(sResult.current.offsetDate).toEqual(nextDate);
+  });
+
+  test('addOffset: should set correct offsetDate when offsetDate is null', () => {
+    const { result } = renderHook(() => useState(newDate(2023, 6, 18)));
+    const { result: sResult, rerender } = renderHook(() =>
+      useDatePickerState({
+        selectedDates: [],
+        onDatesChange: vi.fn(),
+        offsetDate: result.current[0],
+        onOffsetChange: result.current[1],
+      }),
+    );
+
+    const { result: oResult } = renderHook(() =>
+      useDatePickerOffsetPropGetters(sResult.current),
+    );
+
+    const { onClick } = oResult.current.addOffset({ months: 1 });
+
+    // @ts-ignore-next-line
+    act(() => onClick());
+    rerender();
+
+    expect(sResult.current.offsetDate).toEqual(newDate(2023, 7, 18));
+  });
+
+  test('subtractOffset: should set correct offsetDate when offsetDate is null', () => {
+    const { result } = renderHook(() => useState(newDate(2023, 6, 18)));
+    const { result: sResult, rerender } = renderHook(() =>
+      useDatePickerState({
+        selectedDates: [],
+        onDatesChange: vi.fn(),
+        offsetDate: result.current[0],
+        onOffsetChange: result.current[1],
+      }),
+    );
+
+    const { result: oResult } = renderHook(() =>
+      useDatePickerOffsetPropGetters(sResult.current),
+    );
+
+    const { onClick } = oResult.current.subtractOffset({ months: 1 });
+
+    // @ts-ignore-next-line
+    act(() => onClick());
+    rerender();
+
+    expect(sResult.current.offsetDate).toEqual(newDate(2023, 5, 18));
+  });
+});

--- a/src/__test__/use-date-picker-state.test.ts
+++ b/src/__test__/use-date-picker-state.test.ts
@@ -1,5 +1,5 @@
 import { act, renderHook } from '@testing-library/react';
-import { describe, expect, test } from 'vitest';
+import { describe, expect, test, vi } from 'vitest';
 
 import { INITIAL_STATE } from '../__mock__/initial-state';
 import { setOffset, setRangeEnd, setYear } from '../state-reducer';
@@ -9,13 +9,23 @@ import { getCurrentYearPosition } from '../utils/get-current-year-position';
 
 describe('useDatePickerState', () => {
   test('useDatePickerState should return correct initial state', () => {
-    const { result } = renderHook(() => useDatePickerState());
+    const { result } = renderHook(() =>
+      useDatePickerState({
+        selectedDates: [],
+        onDatesChange: vi.fn(),
+      }),
+    );
 
     expect(result.current.state).toEqual(INITIAL_STATE);
   });
 
   test('useDatePickerState should set offset correctly', () => {
-    const { result } = renderHook(() => useDatePickerState());
+    const { result } = renderHook(() =>
+      useDatePickerState({
+        selectedDates: [],
+        onDatesChange: vi.fn(),
+      }),
+    );
 
     const { dispatch } = result.current;
     const { Y, M, D } = getDateParts(newDate());
@@ -29,17 +39,12 @@ describe('useDatePickerState', () => {
   });
 
   test('useDatePickerState should set offsetYear correctly', () => {
-    const { result } = renderHook(() => useDatePickerState());
-
-    const { dispatch } = result.current;
-    const { Y } = getDateParts(newDate());
-
-    act(() => setYear(dispatch, Y + 10));
-    expect(result.current.state.offsetYear).toBe(Y + 10);
-  });
-
-  test('useDatePickerState should set offsetYear correctly', () => {
-    const { result } = renderHook(() => useDatePickerState());
+    const { result } = renderHook(() =>
+      useDatePickerState({
+        selectedDates: [],
+        onDatesChange: vi.fn(),
+      }),
+    );
 
     const { dispatch } = result.current;
     const { Y } = getDateParts(newDate());
@@ -49,7 +54,12 @@ describe('useDatePickerState', () => {
   });
 
   test('useDatePickerState should set rangeEnd correctly', () => {
-    const { result } = renderHook(() => useDatePickerState());
+    const { result } = renderHook(() =>
+      useDatePickerState({
+        selectedDates: [],
+        onDatesChange: vi.fn(),
+      }),
+    );
 
     const { dispatch } = result.current;
     const d = newDate();

--- a/src/__test__/use-date-picker.test.ts
+++ b/src/__test__/use-date-picker.test.ts
@@ -1,6 +1,6 @@
 import { act, renderHook } from '@testing-library/react';
 import { useState } from 'react';
-import { describe, expect, test } from 'vitest';
+import { describe, expect, test, vi } from 'vitest';
 
 import { useDatePicker } from '../use-date-picker';
 import { getDateParts, newDate } from '../utils/date';
@@ -82,6 +82,8 @@ describe('useDatePicker', () => {
 
     const { result } = renderHook(() =>
       useDatePicker({
+        selectedDates: [],
+        onDatesChange: vi.fn(),
         dates: {
           minDate: newDate(Y, M, minDate),
           maxDate: newDate(Y, M, maxDate),
@@ -90,10 +92,12 @@ describe('useDatePicker', () => {
     );
 
     //Ensure that next/previous months buttons are disabled
-    expect(result.current.propGetters.nextMonthButton().disabled).toBe(true);
-    expect(result.current.propGetters.previousMonthButton().disabled).toBe(
+    expect(result.current.propGetters.addOffset({ months: 1 }).disabled).toBe(
       true,
     );
+    expect(
+      result.current.propGetters.subtractOffset({ months: 1 }).disabled,
+    ).toBe(true);
 
     // Ensure that all months disabled expect current
     const enabledMonths = result.current.data.months.filter(

--- a/src/__test__/use-days.test.ts
+++ b/src/__test__/use-days.test.ts
@@ -1,6 +1,6 @@
 import { act, renderHook } from '@testing-library/react';
 import { useState } from 'react';
-import { describe, expect, test } from 'vitest';
+import { describe, expect, test, vi } from 'vitest';
 
 import { useCalendars } from '../use-calendars';
 import { useDatePickerState } from '../use-date-picker-state';
@@ -12,7 +12,10 @@ describe('useDays', () => {
     const d1 = newDate(2022, 11, 9);
     const d2 = newDate(2022, 11, 11);
     const { result: stateResult } = renderHook(() =>
-      useDatePickerState({ selectedDates: [d1, d2] }),
+      useDatePickerState({
+        onDatesChange: vi.fn(),
+        selectedDates: [d1, d2],
+      }),
     );
     const { result } = renderHook(() => useDays(stateResult.current));
 

--- a/src/__test__/use-months.test.ts
+++ b/src/__test__/use-months.test.ts
@@ -1,24 +1,19 @@
 import { act, renderHook } from '@testing-library/react';
-import { describe, expect, test } from 'vitest';
+import { describe, expect, test, vi } from 'vitest';
 
 import { useDatePickerState } from '../use-date-picker-state';
-import {
-  useMonths,
-  useMonthsActions,
-  useMonthsPropGetters,
-} from '../use-months';
+import { useMonths, useMonthsPropGetters } from '../use-months';
 import { createMonths } from '../utils/create-months';
-import {
-  addToDate,
-  getDateParts,
-  newDate,
-  subtractFromDate,
-} from '../utils/date';
 
 // Test Month data
 describe('useMonths', () => {
   test('useMonths should return correct months list', () => {
-    const { result: stateResult } = renderHook(() => useDatePickerState());
+    const { result: stateResult } = renderHook(() =>
+      useDatePickerState({
+        selectedDates: [],
+        onDatesChange: vi.fn(),
+      }),
+    );
     const { result: monthResult } = renderHook(() =>
       useMonths(stateResult.current),
     );
@@ -38,7 +33,9 @@ describe('useMonths', () => {
 // Test Month prop-getters
 describe('useMonthPropGetters', () => {
   test('monthButton should set months correctly', () => {
-    const { result: stateResult } = renderHook(() => useDatePickerState());
+    const { result: stateResult } = renderHook(() =>
+      useDatePickerState({ selectedDates: [], onDatesChange: vi.fn() }),
+    );
     const { result: monthResult } = renderHook(() =>
       useMonths(stateResult.current),
     );
@@ -54,121 +51,6 @@ describe('useMonthPropGetters', () => {
     act(() => onClick());
     expect(stateResult.current.state.offsetDate.getMonth()).toEqual(
       monthResult.current.months[0].$date.getMonth(),
-    );
-  });
-
-  test('previousMonthButton should set previous month', () => {
-    const { result: stateResult } = renderHook(() => useDatePickerState());
-    const { result: mResult, rerender } = renderHook(() =>
-      useMonthsPropGetters(stateResult.current),
-    );
-
-    const { Y, M, D } = getDateParts(stateResult.current.state.offsetDate);
-    const startDate = newDate(Y, M, D);
-
-    const { onClick } = mResult.current.previousMonthButton();
-
-    // @ts-ignore-next-line
-    act(() => onClick());
-
-    expect(stateResult.current.state.offsetDate.getMonth()).toEqual(
-      subtractFromDate(startDate, 1, 'month').getMonth(),
-    );
-
-    // We need rerender to get fresh offsetDate to the useMonthsPropGetters
-    rerender();
-
-    // should move 3 months back
-    const { onClick: onQuarterBack } = mResult.current.previousMonthButton({
-      step: 3,
-    });
-
-    // @ts-ignore-next-line
-    act(() => onQuarterBack());
-
-    expect(stateResult.current.state.offsetDate.getMonth()).toEqual(
-      subtractFromDate(startDate, 4, 'month').getMonth(),
-    );
-  });
-
-  test('nextMonthButton should set next month', () => {
-    const { result: stateResult } = renderHook(() => useDatePickerState());
-    const { result: mResult, rerender } = renderHook(() =>
-      useMonthsPropGetters(stateResult.current),
-    );
-
-    const { Y, M, D } = getDateParts(stateResult.current.state.offsetDate);
-    const startDate = newDate(Y, M, D);
-
-    const { onClick } = mResult.current.nextMonthButton();
-
-    // @ts-ignore-next-line
-    act(() => onClick());
-    expect(stateResult.current.state.offsetDate.getMonth()).toEqual(
-      addToDate(startDate, 1, 'month').getMonth(),
-    );
-
-    // We need rerender to get fresh offsetDate to the useMonthsPropGetters
-    rerender();
-
-    // should move 3 months forward
-    const { onClick: onQuarterForward } = mResult.current.nextMonthButton({
-      step: 3,
-    });
-
-    // @ts-ignore-next-line
-    act(() => onQuarterForward());
-    expect(stateResult.current.state.offsetDate.getMonth()).toEqual(
-      addToDate(startDate, 4, 'month').getMonth(),
-    );
-  });
-});
-
-// Test Month actions
-describe('useMonthsAction', () => {
-  test('setMonth should set correct month', () => {
-    const { result: stateResult } = renderHook(() => useDatePickerState());
-    const { result: mResult } = renderHook(() =>
-      useMonthsActions(stateResult.current),
-    );
-    const { setMonth } = mResult.current;
-
-    const { Y, M, D } = getDateParts(newDate());
-    const nextDate = newDate(Y, M - 3, D);
-
-    act(() => setMonth(nextDate));
-    expect(stateResult.current.state.offsetDate.getMonth()).toBe(
-      nextDate.getMonth(),
-    );
-  });
-
-  test('setPreviousMonth should set previous month', () => {
-    const { result: stateResult } = renderHook(() => useDatePickerState());
-    const { result: mResult } = renderHook(() =>
-      useMonthsActions(stateResult.current),
-    );
-    const { setPreviousMonth } = mResult.current;
-
-    const { Y, M, D } = getDateParts(stateResult.current.state.offsetDate);
-
-    act(() => setPreviousMonth());
-    expect(stateResult.current.state.offsetDate.getMonth()).toBe(
-      subtractFromDate(newDate(Y, M, D), 1, 'month').getMonth(),
-    );
-  });
-
-  test('setNextMonth should set next month', () => {
-    const { result: stateResult } = renderHook(() => useDatePickerState());
-    const { result: mResult } = renderHook(() =>
-      useMonthsActions(stateResult.current),
-    );
-    const { setNextMonth } = mResult.current;
-
-    const { Y, M, D } = getDateParts(stateResult.current.state.offsetDate);
-
-    act(() => setNextMonth());
-    expect(stateResult.current.state.offsetDate.getMonth()).toBe(
-      addToDate(newDate(Y, M, D), 1, 'month').getMonth(),
     );
   });
 });

--- a/src/__test__/use-time.test.ts
+++ b/src/__test__/use-time.test.ts
@@ -1,6 +1,6 @@
 import { act, renderHook } from '@testing-library/react';
 import { useState } from 'react';
-import { describe, expect, test } from 'vitest';
+import { describe, expect, test, vi } from 'vitest';
 
 import { useCalendars } from '../use-calendars';
 import { useDatePickerState } from '../use-date-picker-state';
@@ -9,7 +9,12 @@ import { useTime, useTimePropGetter } from '../use-time';
 
 describe('useTime', () => {
   test('should return correct time array', () => {
-    const { result: stateResult } = renderHook(() => useDatePickerState());
+    const { result: stateResult } = renderHook(() =>
+      useDatePickerState({
+        selectedDates: [],
+        onDatesChange: vi.fn(),
+      }),
+    );
     const { result: timeResult } = renderHook(() =>
       useTime(stateResult.current),
     );

--- a/src/__test__/use-years.test.ts
+++ b/src/__test__/use-years.test.ts
@@ -1,14 +1,15 @@
 import { act, renderHook } from '@testing-library/react';
-import { describe, expect, test } from 'vitest';
+import { describe, expect, test, vi } from 'vitest';
 
 import { useDatePickerState } from '../use-date-picker-state';
-import { useYears, useYearsActions, useYearsPropGetters } from '../use-years';
+import { useYears, useYearsPropGetters } from '../use-years';
 import { createYears } from '../utils/create-years';
-import { getDateParts, newDate } from '../utils/date';
 
 describe('useYears', () => {
   test('useMonths should return correct years list', () => {
-    const { result: stateResult } = renderHook(() => useDatePickerState());
+    const { result: stateResult } = renderHook(() =>
+      useDatePickerState({ selectedDates: [], onDatesChange: vi.fn() }),
+    );
     const { result: monthResult } = renderHook(() =>
       useYears(stateResult.current),
     );
@@ -34,7 +35,9 @@ describe('useYears', () => {
 
 describe('useYearsPropGetters', () => {
   test('yearButton should set year correctly', () => {
-    const { result: stateResult } = renderHook(() => useDatePickerState());
+    const { result: stateResult } = renderHook(() =>
+      useDatePickerState({ selectedDates: [], onDatesChange: vi.fn() }),
+    );
     const { result: yearsResult } = renderHook(() =>
       useYears(stateResult.current),
     );
@@ -55,7 +58,12 @@ describe('useYearsPropGetters', () => {
   });
 
   test('previousYearsButton: should move years pagination one step backward', () => {
-    const { result: stateResult } = renderHook(() => useDatePickerState());
+    const { result: stateResult } = renderHook(() =>
+      useDatePickerState({
+        selectedDates: [],
+        onDatesChange: vi.fn(),
+      }),
+    );
     const { years } = stateResult.current.config;
     const { result: yResult } = renderHook(() =>
       useYearsPropGetters(stateResult.current),
@@ -73,7 +81,12 @@ describe('useYearsPropGetters', () => {
   });
 
   test('nextYearsButton: should move years pagination step forward', () => {
-    const { result: stateResult } = renderHook(() => useDatePickerState());
+    const { result: stateResult } = renderHook(() =>
+      useDatePickerState({
+        selectedDates: [],
+        onDatesChange: vi.fn(),
+      }),
+    );
     const { years } = stateResult.current.config;
     const { result: yResult } = renderHook(() =>
       useYearsPropGetters(stateResult.current),
@@ -87,51 +100,6 @@ describe('useYearsPropGetters', () => {
     act(() => onClick());
     expect(stateResult.current.state.offsetYear).toEqual(
       currentYear + years.step,
-    );
-  });
-});
-
-describe('useYearsAction', () => {
-  test('setYears should set correct year', () => {
-    const { result: stateResult } = renderHook(() => useDatePickerState());
-    const { result: yResult } = renderHook(() =>
-      useYearsActions(stateResult.current),
-    );
-
-    const { Y, M, D } = getDateParts(stateResult.current.state.offsetDate);
-    const { setYear } = yResult.current;
-
-    act(() => setYear(newDate(Y + 3, M, D)));
-    expect(stateResult.current.state.offsetDate.getFullYear()).toBe(Y + 3);
-  });
-
-  test('setPreviousYears: should move years pagination one step backward', () => {
-    const { result: stateResult } = renderHook(() => useDatePickerState());
-    const { result: mResult } = renderHook(() =>
-      useYearsActions(stateResult.current),
-    );
-
-    const currentYear = stateResult.current.state.offsetYear;
-    const { setPreviousYears } = mResult.current;
-
-    act(() => setPreviousYears());
-    expect(stateResult.current.state.offsetYear).toBe(
-      currentYear - stateResult.current.config.years.step,
-    );
-  });
-
-  test('setNextYears: should move years pagination one step forward', () => {
-    const { result: stateResult } = renderHook(() => useDatePickerState());
-    const { result: mResult } = renderHook(() =>
-      useYearsActions(stateResult.current),
-    );
-
-    const currentYear = stateResult.current.state.offsetYear;
-    const { setNextYears } = mResult.current;
-
-    act(() => setNextYears());
-    expect(stateResult.current.state.offsetYear).toBe(
-      currentYear + stateResult.current.config.years.step,
     );
   });
 });

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -23,7 +23,7 @@ export const WEEK_DAYS = [0, 1, 2, 3, 4, 5, 6] as const;
 export const NUMBER_OF_MONTHS = 12;
 export const MINUTES_IN_THE_DAY = 60 * 24; // 1440 :)
 
-// Number of yearn by default to mimic number of month
+// Number of years by default to mimic number of month
 // It will be easy to reuse same layout for years picker
 const DECADE_NUMBER_OF_YEARS = 12;
 export const DEFAULT_YEARS_STEP = 10;

--- a/src/date-picker-provider.tsx
+++ b/src/date-picker-provider.tsx
@@ -11,7 +11,7 @@ export const useDatePickerContext = () => useContext(DatePickerContext);
 
 export const DatePickerProvider: FC<DatePickerProviderProps> = ({
   children,
-  config = {},
+  config,
 }) => (
   <DatePickerContext.Provider value={useDatePicker(config)}>
     {children}

--- a/src/date-picker-state-provider.tsx
+++ b/src/date-picker-state-provider.tsx
@@ -10,7 +10,7 @@ export const useDatePickerStateContext = () =>
 
 export const DatePickerStateProvider: FC<DatePickerProviderProps> = ({
   children,
-  config = {},
+  config,
 }) => (
   <DatePickerStateContext.Provider value={useDatePickerState(config)}>
     {children}

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,7 @@ export * from './types';
 export * from './use-calendars';
 export * from './use-context-hooks';
 export * from './use-date-picker';
+export * from './use-date-picker-offset';
 export * from './use-date-picker-state';
 export * from './use-days';
 export * from './use-months';

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -19,10 +19,6 @@ export interface DPDatesConfig {
   exclude?: DPDateExclude;
 }
 
-export interface DPDatesUserConfig extends Partial<DPDatesConfig> {
-  selectedDates: Date | Date[];
-}
-
 export interface DPYearsConfig {
   numberOfYears: number;
   mode: DPYearsMode;
@@ -57,25 +53,29 @@ export interface DPTimeConfig {
 }
 
 export interface DPUserConfig {
-  selectedDates?: Date[];
-  focusDate?: Date | null;
-  onDatesChange?(d: Date[]): void;
-  locale?: Partial<DPLocaleConfig>;
   calendar?: Partial<DPCalendarConfig>;
-  dates?: Partial<DPDatesUserConfig>;
-  years?: Partial<DPYearsConfig>;
-  time?: Partial<DPTimeConfig>;
+  dates?: Partial<DPDatesConfig>;
   exclude?: DPExcludeConfig;
+  focusDate?: Date;
+  locale?: Partial<DPLocaleConfig>;
+  offsetDate?: Date;
+  onOffsetChange?(d: Date): void;
+  onDatesChange(d: Date[]): void;
+  selectedDates: Date[];
+  time?: Partial<DPTimeConfig>;
+  years?: Partial<DPYearsConfig>;
 }
 
 export interface DPConfig {
-  selectedDates: Date[];
-  focusDate: Date | null;
-  onDatesChange?(d: Date[]): void;
-  locale: DPLocaleConfig;
   calendar: DPCalendarConfig;
   dates: DPDatesConfig;
-  years: DPYearsConfig;
-  time: DPTimeConfig;
   exclude?: DPExcludeConfig;
+  focusDate?: Date;
+  locale: DPLocaleConfig;
+  offsetDate?: Date;
+  onOffsetChange?(d: Date): void;
+  onDatesChange(d: Date[]): void;
+  selectedDates: Date[];
+  time: DPTimeConfig;
+  years: DPYearsConfig;
 }

--- a/src/types/context.ts
+++ b/src/types/context.ts
@@ -7,5 +7,5 @@ export type DatePickerContextValue = ReturnType<DPUseDatePicker>;
 
 export interface DatePickerProviderProps {
   children: ReactNode;
-  config?: DPUserConfig;
+  config: DPUserConfig;
 }

--- a/src/types/hooks.ts
+++ b/src/types/hooks.ts
@@ -2,11 +2,8 @@ import { DPCalendar } from './calendar';
 import { DPUserConfig } from './config';
 import { DPDay } from './day';
 import { DPMonth } from './month';
-import {
-  DPMonthsPropGettersConfig,
-  DPPropGetter,
-  DPPropsGetterConfig,
-} from './prop-getters';
+import { DPOffsetValue } from './offset';
+import { DPPropGetter, DPPropsGetterConfig } from './prop-getters';
 import { DPState } from './state';
 import { DPTime } from './time';
 import { DPYear } from './year';
@@ -31,14 +28,18 @@ export type DPUseMonths = (state: DPState) => {
 
 export type DPUseMonthsPropGetters = (state: DPState) => {
   monthButton: (month: DPMonth, config?: DPPropsGetterConfig) => DPPropGetter;
-  nextMonthButton: (config?: DPMonthsPropGettersConfig) => DPPropGetter;
-  previousMonthButton: (config?: DPMonthsPropGettersConfig) => DPPropGetter;
 };
 
-export type DPUseMonthsActions = (state: DPState) => {
-  setMonth: (d: Date) => void;
-  setNextMonth: () => void;
-  setPreviousMonth: () => void;
+export type DPUseDatePickerOffsetPropGetters = (state: DPState) => {
+  addOffset: (
+    offsetValue: DPOffsetValue,
+    config?: DPPropsGetterConfig,
+  ) => DPPropGetter;
+  setOffset: (date: Date) => DPPropGetter;
+  subtractOffset: (
+    offsetValue: DPOffsetValue,
+    config?: DPPropsGetterConfig,
+  ) => DPPropGetter;
 };
 
 export type DPUseTime = (state: DPState) => {
@@ -59,12 +60,6 @@ export type DPUseYearsPropGetters = (state: DPState) => {
   previousYearsButton: (config?: DPPropsGetterConfig) => DPPropGetter;
 };
 
-export type DPUseYearsActions = (state: DPState) => {
-  setYear: (d: Date) => void;
-  setNextYears: () => void;
-  setPreviousYears: () => void;
-};
-
 export interface DPData
   extends ReturnType<DPUseCalendars>,
     ReturnType<DPUseDays>,
@@ -76,16 +71,12 @@ export interface DPPropGetters
   extends ReturnType<DPUseDaysPropGetters>,
     ReturnType<DPUseMonthsPropGetters>,
     ReturnType<DPUseTimePropGetter>,
-    ReturnType<DPUseYearsPropGetters> {}
+    ReturnType<DPUseYearsPropGetters>,
+    ReturnType<DPUseDatePickerOffsetPropGetters> {}
 
-export interface DPActions
-  extends ReturnType<DPUseMonthsActions>,
-    ReturnType<DPUseYearsActions> {}
-
-export type DPUseDatePicker = (config?: DPUserConfig) => {
+export type DPUseDatePicker = (config: DPUserConfig) => {
   data: DPData;
   propGetters: DPPropGetters;
-  actions: DPActions;
 };
 
 export type DPUseContextCalendars = () => ReturnType<DPUseCalendars>;
@@ -97,7 +88,6 @@ export type DPUseContextDaysPropGetters =
 export type DPUseContextMonths = () => ReturnType<DPUseMonths>;
 export type DPUseContextMonthsPropGetters =
   () => ReturnType<DPUseMonthsPropGetters>;
-export type DPUseContextMonthsActions = () => ReturnType<DPUseMonthsActions>;
 
 export type DPUseContextTime = () => ReturnType<DPUseTime>;
 export type DPUseContextTimePropGetters = () => ReturnType<DPUseTimePropGetter>;
@@ -105,4 +95,6 @@ export type DPUseContextTimePropGetters = () => ReturnType<DPUseTimePropGetter>;
 export type DPUseContextYears = () => ReturnType<DPUseYears>;
 export type DPUseContextYearsPropGetters =
   () => ReturnType<DPUseYearsPropGetters>;
-export type DPUseContextYearsActions = () => ReturnType<DPUseYearsActions>;
+
+export type DPUseContextDatePickerOffsetPropGetters =
+  () => ReturnType<DPUseDatePickerOffsetPropGetters>;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -5,6 +5,7 @@ export * from './date';
 export * from './day';
 export * from './hooks';
 export * from './month';
+export * from './offset';
 export * from './prop-getters';
 export * from './state';
 export * from './time';

--- a/src/types/offset.ts
+++ b/src/types/offset.ts
@@ -1,0 +1,5 @@
+export interface DPOffsetValue {
+  days?: number;
+  months?: number;
+  years?: number;
+}

--- a/src/types/prop-getters.ts
+++ b/src/types/prop-getters.ts
@@ -5,10 +5,6 @@ export interface DPPropsGetterConfig extends Record<string, unknown> {
   disabled?: boolean;
 }
 
-export interface DPMonthsPropGettersConfig extends DPPropsGetterConfig {
-  step?: number;
-}
-
 export interface DPPropGetter extends Record<string, unknown> {
   role: 'button';
   tabIndex: number;

--- a/src/types/state.ts
+++ b/src/types/state.ts
@@ -9,7 +9,7 @@ import {
 import { DPConfig } from './config';
 
 export interface DPReducerState {
-  focusDate: Date | null;
+  focusDate?: Date;
   rangeEnd: Date | null;
   offsetDate: Date;
   offsetYear: number;
@@ -45,5 +45,6 @@ export interface DPState {
   dispatch: Dispatch<DPReducerAction>;
   state: DPReducerState;
   selectedDates: Date[];
+  offsetDate: Date;
   config: DPConfig;
 }

--- a/src/use-calendars.ts
+++ b/src/use-calendars.ts
@@ -1,3 +1,5 @@
+import { useMemo } from 'react';
+
 import type { DPUseCalendars } from './types';
 import { createCalendars } from './utils/create-calendars';
 import { createWeekdays } from './utils/create-weekdays';
@@ -5,8 +7,11 @@ import { createWeekdays } from './utils/create-weekdays';
 export const useCalendars: DPUseCalendars = (state) => {
   const calendars = createCalendars(state);
 
-  return {
-    calendars,
-    weekDays: createWeekdays(calendars[0], state.config),
-  };
+  return useMemo(
+    () => ({
+      calendars,
+      weekDays: createWeekdays(calendars[0], state.config),
+    }),
+    [calendars, state.config],
+  );
 };

--- a/src/use-context-hooks.ts
+++ b/src/use-context-hooks.ts
@@ -1,26 +1,22 @@
 import { useDatePickerStateContext } from './date-picker-state-provider';
 import type {
   DPUseContextCalendars,
+  DPUseContextDatePickerOffsetPropGetters,
   DPUseContextDays,
   DPUseContextDaysPropGetters,
   DPUseContextMonths,
-  DPUseContextMonthsActions,
   DPUseContextMonthsPropGetters,
   DPUseContextTime,
   DPUseContextTimePropGetters,
   DPUseContextYears,
-  DPUseContextYearsActions,
   DPUseContextYearsPropGetters,
 } from './types';
 import { useCalendars } from './use-calendars';
+import { useDatePickerOffsetPropGetters } from './use-date-picker-offset';
 import { useDays, useDaysPropGetters } from './use-days';
-import {
-  useMonths,
-  useMonthsActions,
-  useMonthsPropGetters,
-} from './use-months';
+import { useMonths, useMonthsPropGetters } from './use-months';
 import { useTime, useTimePropGetter } from './use-time';
-import { useYears, useYearsActions, useYearsPropGetters } from './use-years';
+import { useYears, useYearsPropGetters } from './use-years';
 
 export const useContextCalendars: DPUseContextCalendars = () =>
   useCalendars(useDatePickerStateContext());
@@ -37,9 +33,6 @@ export const useContextMonths: DPUseContextMonths = () =>
 export const useContextMonthsPropGetters: DPUseContextMonthsPropGetters = () =>
   useMonthsPropGetters(useDatePickerStateContext());
 
-export const useContextMonthsActions: DPUseContextMonthsActions = () =>
-  useMonthsActions(useDatePickerStateContext());
-
 export const useContextTime: DPUseContextTime = () =>
   useTime(useDatePickerStateContext());
 
@@ -52,5 +45,5 @@ export const useContextYears: DPUseContextYears = () =>
 export const useContextYearsPropGetters: DPUseContextYearsPropGetters = () =>
   useYearsPropGetters(useDatePickerStateContext());
 
-export const useContextYearsActions: DPUseContextYearsActions = () =>
-  useYearsActions(useDatePickerStateContext());
+export const useContextDatePickerOffsetPropGetters: DPUseContextDatePickerOffsetPropGetters =
+  () => useDatePickerOffsetPropGetters(useDatePickerStateContext());

--- a/src/use-date-picker-offset.ts
+++ b/src/use-date-picker-offset.ts
@@ -1,0 +1,88 @@
+import { useCallback } from 'react';
+
+import {
+  DPOffsetValue,
+  DPPropsGetterConfig,
+  DPUseDatePickerOffsetPropGetters,
+} from './types';
+import { callAll, skipFirst } from './utils/call-all';
+import { createPropGetter } from './utils/create-prop-getter';
+import { getNextOffsetDate, setDPOffset } from './utils/offset';
+import { maxDateAndAfter, minDateAndBefore } from './utils/predicates';
+
+export const useDatePickerOffsetPropGetters: DPUseDatePickerOffsetPropGetters =
+  (state) => {
+    const {
+      config: { dates },
+    } = state;
+    const { minDate, maxDate } = dates;
+
+    const addOffset = useCallback(
+      (
+        offsetValue: DPOffsetValue,
+        { disabled, onClick, ...rest }: DPPropsGetterConfig = {},
+      ) => {
+        const nextDate = getNextOffsetDate(state.offsetDate, offsetValue);
+
+        const isDisabled = !!disabled || maxDateAndAfter(maxDate, nextDate);
+
+        return createPropGetter(
+          isDisabled,
+          (evt) =>
+            callAll(onClick, skipFirst(setDPOffset(state)))(evt, nextDate),
+          rest,
+        );
+      },
+      [maxDate, state],
+    );
+
+    const subtractOffset = useCallback(
+      (
+        { days = 0, months = 0, years = 0 }: DPOffsetValue,
+        { disabled, onClick, ...rest }: DPPropsGetterConfig = {},
+      ) => {
+        const negativeOffsetValue = {
+          days: -days,
+          months: -months,
+          years: -years,
+        };
+
+        const nextDate = getNextOffsetDate(
+          state.offsetDate,
+          negativeOffsetValue,
+        );
+
+        const isDisabled = !!disabled || minDateAndBefore(minDate, nextDate);
+
+        return createPropGetter(
+          isDisabled,
+          (evt) =>
+            callAll(onClick, skipFirst(setDPOffset(state)))(evt, nextDate),
+          rest,
+        );
+      },
+      [minDate, state],
+    );
+
+    const setOffset = useCallback(
+      (d: Date, { disabled, onClick, ...rest }: DPPropsGetterConfig = {}) => {
+        const isDisabled =
+          !!disabled ||
+          minDateAndBefore(minDate, d) ||
+          maxDateAndAfter(maxDate, d);
+
+        return createPropGetter(
+          isDisabled,
+          (evt) => callAll(onClick, skipFirst(setDPOffset(state)))(evt, d),
+          rest,
+        );
+      },
+      [state, maxDate, minDate],
+    );
+
+    return {
+      addOffset,
+      setOffset,
+      subtractOffset,
+    };
+  };

--- a/src/use-date-picker-state.ts
+++ b/src/use-date-picker-state.ts
@@ -10,7 +10,7 @@ import type {
 import { createConfig } from './utils/config';
 import { createInitialState } from './utils/create-initial-state';
 
-export const useDatePickerState = (config?: DPUserConfig): DPState => {
+export const useDatePickerState = (config: DPUserConfig): DPState => {
   const dpConfig = createConfig(config);
 
   const [state, dispatch] = useReducer<
@@ -20,6 +20,7 @@ export const useDatePickerState = (config?: DPUserConfig): DPState => {
   return {
     dispatch,
     selectedDates: dpConfig.selectedDates,
+    offsetDate: dpConfig.offsetDate || state.offsetDate,
     state,
     config: dpConfig,
   };

--- a/src/use-date-picker.ts
+++ b/src/use-date-picker.ts
@@ -1,14 +1,11 @@
 import type { DPUseDatePicker } from './types';
 import { useCalendars } from './use-calendars';
+import { useDatePickerOffsetPropGetters } from './use-date-picker-offset';
 import { useDatePickerState } from './use-date-picker-state';
 import { useDays, useDaysPropGetters } from './use-days';
-import {
-  useMonths,
-  useMonthsActions,
-  useMonthsPropGetters,
-} from './use-months';
+import { useMonths, useMonthsPropGetters } from './use-months';
 import { useTime, useTimePropGetter } from './use-time';
-import { useYears, useYearsActions, useYearsPropGetters } from './use-years';
+import { useYears, useYearsPropGetters } from './use-years';
 
 export const useDatePicker: DPUseDatePicker = (config) => {
   const dpState = useDatePickerState(config);
@@ -26,10 +23,7 @@ export const useDatePicker: DPUseDatePicker = (config) => {
       ...useMonthsPropGetters(dpState),
       ...useTimePropGetter(dpState),
       ...useYearsPropGetters(dpState),
-    },
-    actions: {
-      ...useMonthsActions(dpState),
-      ...useYearsActions(dpState),
+      ...useDatePickerOffsetPropGetters(dpState),
     },
   };
 };

--- a/src/use-days.ts
+++ b/src/use-days.ts
@@ -1,4 +1,4 @@
-import { useCallback } from 'react';
+import { useCallback, useMemo } from 'react';
 
 import { setFocus, setRangeEnd as setRangeEndAction } from './state-reducer';
 import type {
@@ -14,10 +14,14 @@ import { formatDate, getCleanDate } from './utils/date';
 import { getMultipleDates } from './utils/get-multiple-dates';
 import { includeDate, isSame } from './utils/predicates';
 
-export const useDays: DPUseDays = ({ selectedDates, config: { locale } }) => ({
-  selectedDates,
-  formattedDates: selectedDates.map((d: Date) => formatDate(d, locale)),
-});
+export const useDays: DPUseDays = ({ selectedDates, config: { locale } }) =>
+  useMemo(
+    () => ({
+      selectedDates,
+      formattedDates: selectedDates.map((d: Date) => formatDate(d, locale)),
+    }),
+    [selectedDates, locale],
+  );
 
 export const useDaysPropGetters: DPUseDaysPropGetters = ({
   config,
@@ -51,18 +55,16 @@ export const useDaysPropGetters: DPUseDaysPropGetters = ({
           callAll(
             onClick,
             skipFirst((d: Date) => {
-              if (onDatesChange && typeof onDatesChange === 'function') {
-                const nextSelectedDates = getMultipleDates(
-                  selectedDates,
-                  d,
-                  config.dates,
-                );
-                setFocus(
-                  dispatch,
-                  includeDate(nextSelectedDates, d) ? d : null,
-                );
-                onDatesChange(nextSelectedDates);
-              }
+              const nextSelectedDates = getMultipleDates(
+                selectedDates,
+                d,
+                config.dates,
+              );
+              setFocus(
+                dispatch,
+                includeDate(nextSelectedDates, d) ? d : undefined,
+              );
+              onDatesChange(nextSelectedDates);
             }),
           )(evt, $date);
         },

--- a/src/use-months.ts
+++ b/src/use-months.ts
@@ -1,44 +1,29 @@
-import { useCallback } from 'react';
+import { useCallback, useMemo } from 'react';
 
-import { setOffset } from './state-reducer';
 import type {
   DPMonth,
-  DPMonthsPropGettersConfig,
   DPPropsGetterConfig,
   DPUseMonths,
-  DPUseMonthsActions,
   DPUseMonthsPropGetters,
 } from './types';
 import { callAll, skipFirst } from './utils/call-all';
 import { createMonths } from './utils/create-months';
 import { createPropGetter } from './utils/create-prop-getter';
-import {
-  addToDate,
-  getFirstDayOfTheMonth,
-  subtractFromDate,
-} from './utils/date';
-import { maxDateAndAfter, minDateAndBeforeFirstDay } from './utils/predicates';
+import { setDPOffset } from './utils/offset';
 
 export const useMonths: DPUseMonths = ({
   selectedDates,
-  state: { offsetDate },
+  offsetDate,
   config: { locale, dates },
-}) => ({
-  months: createMonths(offsetDate, selectedDates, locale, dates),
-});
-
-export const useMonthsPropGetters: DPUseMonthsPropGetters = ({
-  state: { offsetDate },
-  config: { dates },
-  dispatch,
-}) => {
-  const { minDate, maxDate } = dates;
-
-  const callSetOffset = useCallback(
-    (d: Date) => setOffset(dispatch, d),
-    [dispatch],
+}) =>
+  useMemo(
+    () => ({
+      months: createMonths(offsetDate, selectedDates, locale, dates),
+    }),
+    [dates, locale, offsetDate, selectedDates],
   );
 
+export const useMonthsPropGetters: DPUseMonthsPropGetters = (dpState) => {
   const monthButton = useCallback(
     (
       { $date, disabled, selected }: DPMonth,
@@ -46,76 +31,12 @@ export const useMonthsPropGetters: DPUseMonthsPropGetters = ({
     ) =>
       createPropGetter(
         !!disabledProps || disabled,
-        (evt) => callAll(onClick, skipFirst(callSetOffset))(evt, $date),
+        (evt) => callAll(onClick, skipFirst(setDPOffset(dpState)))(evt, $date),
         rest,
         selected,
       ),
-    [callSetOffset],
+    [dpState],
   );
 
-  const nextMonthButton = useCallback(
-    ({
-      onClick,
-      disabled,
-      step = 1,
-      ...rest
-    }: DPMonthsPropGettersConfig = {}) => {
-      const nextMonth = addToDate(offsetDate, step, 'month');
-      const isDisabled =
-        !!disabled ||
-        maxDateAndAfter(maxDate, getFirstDayOfTheMonth(nextMonth));
-
-      return createPropGetter(
-        isDisabled,
-        (evt) => callAll(onClick, skipFirst(callSetOffset))(evt, nextMonth),
-        rest,
-      );
-    },
-    [offsetDate, maxDate, callSetOffset],
-  );
-
-  const previousMonthButton = useCallback(
-    ({
-      onClick,
-      disabled,
-      step = 1,
-      ...rest
-    }: DPMonthsPropGettersConfig = {}) => {
-      const nextMonth = subtractFromDate(offsetDate, step, 'month');
-      const isDisabled =
-        !!disabled || minDateAndBeforeFirstDay(minDate, nextMonth);
-
-      return createPropGetter(
-        isDisabled,
-        (evt) => callAll(onClick, skipFirst(callSetOffset))(evt, nextMonth),
-        rest,
-      );
-    },
-    [offsetDate, minDate, callSetOffset],
-  );
-
-  return { monthButton, nextMonthButton, previousMonthButton };
-};
-
-export const useMonthsActions: DPUseMonthsActions = ({
-  state: { offsetDate },
-  dispatch,
-}) => {
-  const setMonth = useCallback((d: Date) => setOffset(dispatch, d), [dispatch]);
-
-  const setNextMonth = useCallback(
-    () => setMonth(addToDate(offsetDate, 1, 'month')),
-    [offsetDate, setMonth],
-  );
-
-  const setPreviousMonth = useCallback(
-    () => setMonth(subtractFromDate(offsetDate, 1, 'month')),
-    [offsetDate, setMonth],
-  );
-
-  return {
-    setMonth,
-    setNextMonth,
-    setPreviousMonth,
-  };
+  return { monthButton };
 };

--- a/src/use-time.ts
+++ b/src/use-time.ts
@@ -1,4 +1,4 @@
-import { useCallback } from 'react';
+import { useCallback, useMemo } from 'react';
 
 import { setFocus } from './state-reducer';
 import type {
@@ -12,9 +12,13 @@ import { createPropGetter } from './utils/create-prop-getter';
 import { createTime } from './utils/create-time';
 import { isSame } from './utils/predicates';
 
-export const useTime: DPUseTime = ({ state: { focusDate }, config }) => ({
-  time: createTime(focusDate, config),
-});
+export const useTime: DPUseTime = ({ state: { focusDate }, config }) =>
+  useMemo(
+    () => ({
+      time: createTime(focusDate, config),
+    }),
+    [focusDate, config],
+  );
 
 export const useTimePropGetter: DPUseTimePropGetter = ({
   selectedDates,
@@ -34,13 +38,11 @@ export const useTimePropGetter: DPUseTimePropGetter = ({
           callAll(
             onClick,
             skipFirst((d: Date) => {
-              if (onDatesChange && typeof onDatesChange === 'function') {
-                const newSelected = selectedDates.map((selected) => {
-                  return isSame(focusDate as Date, selected) ? d : selected;
-                });
-                setFocus(dispatch, d);
-                onDatesChange(newSelected);
-              }
+              const newSelected = selectedDates.map((selected) => {
+                return isSame(focusDate as Date, selected) ? d : selected;
+              });
+              setFocus(dispatch, d);
+              onDatesChange(newSelected);
             }),
           )(evt, $date);
         },

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -11,15 +11,17 @@ import { includeDate } from './predicates';
 
 export const createConfig = ({
   selectedDates = [],
-  focusDate = null,
   onDatesChange,
+  focusDate,
+  offsetDate,
+  onOffsetChange,
   calendar = {},
   dates = {},
   locale,
   time = {},
   exclude = {},
   years,
-}: DPUserConfig = {}): DPConfig => {
+}: DPUserConfig): DPConfig => {
   const { minDate, maxDate, ...restDates } = dates;
   const { offsets = [], ...restCalendarParams } = calendar;
   const { minTime, maxTime, ...restTime } = time;
@@ -28,12 +30,14 @@ export const createConfig = ({
   const [minT, maxT] = sortMinMax(minTime, maxTime, (a, b) => a.h - b.h);
 
   const focus =
-    focusDate && includeDate(selectedDates, focusDate) ? focusDate : null;
+    focusDate && includeDate(selectedDates, focusDate) ? focusDate : undefined;
 
   return {
     selectedDates,
-    focusDate: focus,
     onDatesChange,
+    offsetDate,
+    onOffsetChange,
+    focusDate: focus,
     calendar: {
       ...DEFAULT_CALENDAR_CONFIG,
       ...restCalendarParams,

--- a/src/utils/create-calendars.ts
+++ b/src/utils/create-calendars.ts
@@ -69,8 +69,8 @@ export const createCalendars = ({
   selectedDates,
   state,
   config,
+  offsetDate,
 }: DPState): DPCalendar[] => {
-  const { offsetDate } = state;
   return config.calendar.offsets.map((offset) =>
     createCalendar(
       addToDate(offsetDate, offset, 'month'),

--- a/src/utils/create-initial-state.ts
+++ b/src/utils/create-initial-state.ts
@@ -6,20 +6,22 @@ import { getCurrentYearPosition } from './get-current-year-position';
 export const createInitialState = (config: DPConfig): DPReducerState => {
   const {
     selectedDates,
+    offsetDate,
     focusDate,
     dates: { minDate, maxDate },
     years,
   } = config;
 
-  const offsetDate =
-    selectedDates.length > 0
-      ? selectedDates[selectedDates.length - 1]
-      : getCalendarStartDate(minDate, maxDate, getCleanDate(newDate()));
+  const oDate = offsetDate
+    ? offsetDate
+    : selectedDates.length > 0
+    ? selectedDates[selectedDates.length - 1]
+    : getCalendarStartDate(minDate, maxDate, getCleanDate(newDate()));
 
   return {
     focusDate,
     rangeEnd: null,
-    offsetDate,
-    offsetYear: getCurrentYearPosition(getDateParts(offsetDate).Y, years),
+    offsetDate: oDate,
+    offsetYear: getCurrentYearPosition(getDateParts(oDate).Y, years),
   };
 };

--- a/src/utils/create-time.ts
+++ b/src/utils/create-time.ts
@@ -4,7 +4,7 @@ import { formatTime, getDateParts, getTimeDate, newDate } from './date';
 import { isSame, maxDateAndAfter, minDateAndBefore } from './predicates';
 
 export const createTime = (
-  d: Date | null,
+  d: Date | undefined,
   { time, locale }: DPConfig,
 ): DPTime[] => {
   const NOW = newDate();

--- a/src/utils/offset.ts
+++ b/src/utils/offset.ts
@@ -1,0 +1,28 @@
+import { setOffset } from '../state-reducer';
+import { DPOffsetValue, DPState } from '../types';
+import { addToDate } from './date';
+
+export const setDPOffset =
+  ({ dispatch, config: { onOffsetChange, offsetDate } }: DPState) =>
+  (d: Date): void => {
+    // Prevent to call reducer action if offsetDate is external
+    if (!onOffsetChange && !offsetDate) setOffset(dispatch, d);
+    if (onOffsetChange) onOffsetChange(d);
+  };
+
+export const getNextOffsetDate = (
+  d: Date,
+  { days, months, years }: DPOffsetValue,
+): Date => {
+  let nextDate = d;
+  if (days && days !== 0) {
+    nextDate = addToDate(nextDate, days, 'date');
+  }
+  if (months && months !== 0) {
+    nextDate = addToDate(nextDate, months, 'month');
+  }
+  if (years && years !== 0) {
+    nextDate = addToDate(nextDate, years, 'year');
+  }
+  return nextDate;
+};

--- a/src/utils/predicates.ts
+++ b/src/utils/predicates.ts
@@ -27,4 +27,4 @@ export const minDateAndBeforeFirstDay = (
 ): boolean => !!minDate && isBefore(date, getFirstDayOfTheMonth(minDate));
 
 export const includeDate = (dates: Date[], d: Date): boolean =>
-  dates.some((date) => isSame(getCleanDate(date), d));
+  dates.some((date) => isSame(getCleanDate(date), getCleanDate(d)));


### PR DESCRIPTION
- selectedDates and onDatesChange is mandatory
- offsetDate and onOffset change in config, allows to manipulate offsetDate outside of hook (input, buttons, etc...)
- remove actions
- remove next/previous month prop-getter
- add useDatePickerOffsetPropGetters to manipulate state