### PR TITLE
fix: correctly disabled/enabled addOffset propsGetter with maxDate

### DIFF
--- a/packages/datepicker/src/use-date-picker-offset.ts
+++ b/packages/datepicker/src/use-date-picker-offset.ts
@@ -8,7 +8,11 @@ import {
 import { callAll, skipFirst } from './utils/call-all';
 import { createPropGetter } from './utils/create-prop-getter';
 import { getNextOffsetDate, setDPOffset } from './utils/offset';
-import { maxDateAndAfter, minDateAndBefore } from './utils/predicates';
+import {
+  isAfterMaxMonth,
+  maxDateAndAfter,
+  minDateAndBefore,
+} from './utils/predicates';
 
 export const useDatePickerOffsetPropGetters: DPUseDatePickerOffsetPropGetters =
   (state) => {
@@ -23,8 +27,12 @@ export const useDatePickerOffsetPropGetters: DPUseDatePickerOffsetPropGetters =
         { disabled, onClick, ...rest }: DPPropsGetterConfig = {},
       ) => {
         const nextDate = getNextOffsetDate(state.offsetDate, offsetValue);
+        const disabledDueToMaxDateAndMonthOffset =
+          !!offsetValue.months &&
+          maxDateAndAfter(maxDate, nextDate) &&
+          isAfterMaxMonth(nextDate.getMonth(), maxDate);
 
-        const isDisabled = !!disabled || maxDateAndAfter(maxDate, nextDate);
+        const isDisabled = !!disabled || disabledDueToMaxDateAndMonthOffset;
 
         return createPropGetter(
           isDisabled,

--- a/packages/datepicker/src/utils/predicates.ts
+++ b/packages/datepicker/src/utils/predicates.ts
@@ -30,8 +30,14 @@ export const isBeforeMinMonth = (month: number, minDate?: Date): boolean =>
 export const isBeforeMinYear = (year: number, minDate?: Date): boolean =>
   !!minDate && year < getDateParts(minDate).Y;
 
-export const isAfterMaxMonth = (month: number, maxDate?: Date): boolean =>
-  !!maxDate && month > getDateParts(maxDate).M;
+export const isAfterMaxMonth = (month: number, maxDate?: Date): boolean => {
+  const maxDateMonth = maxDate && getDateParts(maxDate).M;
+  // edge case comparing maxDate in December and month in January
+  if (month === 0 && maxDateMonth === 11) {
+    return true;
+  }
+  return !!maxDate && month > getDateParts(maxDate).M;
+};
 
 export const isAfterMaxYear = (year: number, maxDate?: Date): boolean =>
   !!maxDate && year > getDateParts(maxDate).Y;


### PR DESCRIPTION
Example: single mode datepicker with `maxDate` prop and selected date

When is `nextDate` (calculated with selected value and offset value) higher than `maxDate`, disabled value returned from `propsGetter` is true even when it should not be.

`maxDate`: 20th Dec 2023
selected date: 25th Nov 2023

`propGetters.addOffset({ months: 1 }).disabled` returns `true` when datepicker renders November month 
Cause: `nextDate` is calculated as 25th Dec (25th Nov + 1 month). It's higher than `maxDate`and `propsGetter` returns `disabled: true`.
When you select for example 15th Nov (`nextDate` is then 15 Dec - lower than `maxDate`) `propsGetter` returns `disabled: false`.

`propGetters` should in both cases return `disabled: false` because you need to shift on next month.