### PR TITLE
fix: correctly disabled/enabled addOffset propsGetter with maxDate using the offsetValue 

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "datepicker",
-  "version": "6.5.1",
+  "version": "6.6.0",
   "description": "The ultimate tool to create a date, range and time picker in your React applications.",
   "scripts": {
     "clean": "rimraf node_modules",

--- a/packages/datepicker/src/__test__/offset.test.ts
+++ b/packages/datepicker/src/__test__/offset.test.ts
@@ -3,8 +3,12 @@ import { useState } from 'react';
 import { describe, expect, test, vi } from 'vitest';
 
 import { useDatePickerState } from '../use-date-picker-state';
-import { getCleanDate, newDate } from '../utils/date';
-import { getNextOffsetDate, setDPOffset } from '../utils/offset';
+import { getCleanDate, newDate, subtractFromDate } from '../utils/date';
+import {
+  getEdgedOffsetDate,
+  getNextOffsetDate,
+  setDPOffset,
+} from '../utils/offset';
 
 describe('setDPOffset', () => {
   test('should set offset without onOffsetChange', () => {
@@ -79,5 +83,65 @@ describe('getNextOffsetDate', () => {
       years: -1,
     });
     expect(testResult4).toEqual(getCleanDate(newDate(2020, 11, 30)));
+  });
+});
+
+describe('getEdgedOffsetDate', () => {
+  test('should return offsetDate when dateEdge is not provided', () => {
+    const offsetDate = newDate(2022, 11, 11);
+    const result = getEdgedOffsetDate(offsetDate, {
+      days: 0,
+      months: 0,
+      years: 0,
+    });
+    expect(result).toEqual(offsetDate);
+  });
+
+  test('should return offsetDate when offsetDate and dateEdge are the same', () => {
+    const offsetDate = newDate(2022, 11, 11);
+    const dateEdge = newDate(2022, 11, 11);
+    const result = getEdgedOffsetDate(
+      offsetDate,
+      { days: 0, months: 0, years: 0 },
+      dateEdge,
+    );
+    expect(result).toEqual(offsetDate);
+  });
+
+  test('should return offsetDate when days, months, and years are all zero', () => {
+    const offsetDate = newDate(2022, 11, 11);
+    const dateEdge = newDate(2022, 11, 12);
+    const result = getEdgedOffsetDate(
+      offsetDate,
+      { days: 0, months: 0, years: 0 },
+      dateEdge,
+    );
+    expect(result).toEqual(offsetDate);
+  });
+
+  test('should return date edge - offsetValue if the offset date + offsetValue is greater then max edge', () => {
+    const offsetDate = newDate(2022, 11, 11);
+    const offsetValue = { days: 0, months: 1, years: 0 };
+    const maxDateEdge = newDate(2022, 11, 12);
+    const result = getEdgedOffsetDate(offsetDate, offsetValue, maxDateEdge);
+    const expectedDate = subtractFromDate(
+      maxDateEdge,
+      offsetValue.months,
+      'month',
+    );
+    expect(result).toEqual(expectedDate);
+  });
+
+  test('should return date edge - offsetValue if the offset date + offsetValue is greater then min edge', () => {
+    const offsetDate = newDate(2022, 11, 11);
+    const offsetValue = { days: 0, months: -1, years: 0 };
+    const minDateEdge = newDate(2022, 10, 12);
+    const result = getEdgedOffsetDate(offsetDate, offsetValue, minDateEdge);
+    const expectedDate = subtractFromDate(
+      minDateEdge,
+      offsetValue.months,
+      'month',
+    );
+    expect(result).toEqual(expectedDate);
   });
 });

--- a/packages/datepicker/src/__test__/use-date-picker.test.ts
+++ b/packages/datepicker/src/__test__/use-date-picker.test.ts
@@ -91,13 +91,13 @@ describe('useDatePicker', () => {
       }),
     );
 
-    //Ensure that next/previous months buttons are disabled
+    //Ensure that next month button is disabled
     expect(result.current.propGetters.addOffset({ months: 1 }).disabled).toBe(
       true,
     );
     expect(
       result.current.propGetters.subtractOffset({ months: 1 }).disabled,
-    ).toBe(true);
+    ).toBe(undefined);
 
     // Ensure that all months disabled expect current
     const enabledMonths = result.current.data.months.filter(

--- a/packages/datepicker/src/use-date-picker-offset.ts
+++ b/packages/datepicker/src/use-date-picker-offset.ts
@@ -7,7 +7,11 @@ import {
 } from './types';
 import { callAll, skipFirst } from './utils/call-all';
 import { createPropGetter } from './utils/create-prop-getter';
-import { getNextOffsetDate, setDPOffset } from './utils/offset';
+import {
+  getEdgedOffsetDate,
+  getNextOffsetDate,
+  setDPOffset,
+} from './utils/offset';
 import { maxDateAndAfter, minDateAndBefore } from './utils/predicates';
 
 export const useDatePickerOffsetPropGetters: DPUseDatePickerOffsetPropGetters =
@@ -22,7 +26,12 @@ export const useDatePickerOffsetPropGetters: DPUseDatePickerOffsetPropGetters =
         offsetValue: DPOffsetValue,
         { disabled, onClick, ...rest }: DPPropsGetterConfig = {},
       ) => {
-        const nextDate = getNextOffsetDate(state.offsetDate, offsetValue);
+        const offsetDate = getEdgedOffsetDate(
+          state.offsetDate,
+          offsetValue,
+          maxDate,
+        );
+        const nextDate = getNextOffsetDate(offsetDate, offsetValue);
 
         const isDisabled = !!disabled || maxDateAndAfter(maxDate, nextDate);
 
@@ -47,10 +56,12 @@ export const useDatePickerOffsetPropGetters: DPUseDatePickerOffsetPropGetters =
           years: -years,
         };
 
-        const nextDate = getNextOffsetDate(
+        const offsetDate = getEdgedOffsetDate(
           state.offsetDate,
           negativeOffsetValue,
+          minDate,
         );
+        const nextDate = getNextOffsetDate(offsetDate, negativeOffsetValue);
 
         const isDisabled = !!disabled || minDateAndBefore(minDate, nextDate);
 

--- a/packages/datepicker/src/utils/offset.ts
+++ b/packages/datepicker/src/utils/offset.ts
@@ -30,21 +30,21 @@ export const getNextOffsetDate = (
 
 export const getEdgedOffsetDate = (
   offsetDate: Date,
-  { days, months, years }: DPOffsetValue,
+  { days = 0, months = 0, years = 0 }: DPOffsetValue,
   dateEdge?: Date,
 ): Date => {
-  if (dateEdge) {
-    if (isSame(offsetDate, dateEdge)) return offsetDate;
-    if (days && days !== 0) {
-      return calculateNewDateWithOffset(offsetDate, dateEdge, days, 'date');
-    }
-    if (months && months !== 0) {
-      return calculateNewDateWithOffset(offsetDate, dateEdge, months, 'month');
-    }
-    if (years && years !== 0) {
-      return calculateNewDateWithOffset(offsetDate, dateEdge, years, 'year');
-    }
+  if (!dateEdge) return offsetDate;
+  if (isSame(offsetDate, dateEdge)) return offsetDate;
+  if (days !== 0) {
+    return calculateNewDateWithOffset(offsetDate, dateEdge, days, 'date');
   }
+  if (months !== 0) {
+    return calculateNewDateWithOffset(offsetDate, dateEdge, months, 'month');
+  }
+  if (years !== 0) {
+    return calculateNewDateWithOffset(offsetDate, dateEdge, years, 'year');
+  }
+
   return offsetDate;
 };
 

--- a/packages/datepicker/src/utils/offset.ts
+++ b/packages/datepicker/src/utils/offset.ts
@@ -1,6 +1,7 @@
 import { setOffset } from '../state-reducer';
 import { DPOffsetValue, DPState } from '../types';
-import { addToDate } from './date';
+import { addToDate, subtractFromDate } from './date';
+import { isSame, maxDateAndAfter, minDateAndBefore } from './predicates';
 
 export const setDPOffset =
   ({ dispatch, config: { onOffsetChange, offsetDate } }: DPState) =>
@@ -25,4 +26,44 @@ export const getNextOffsetDate = (
     nextDate = addToDate(nextDate, years, 'year');
   }
   return nextDate;
+};
+
+export const getEdgedOffsetDate = (
+  offsetDate: Date,
+  { days, months, years }: DPOffsetValue,
+  dateEdge?: Date,
+): Date => {
+  if (dateEdge) {
+    if (isSame(offsetDate, dateEdge)) return offsetDate;
+    if (days && days !== 0) {
+      return calculateNewDateWithOffset(offsetDate, dateEdge, days, 'date');
+    }
+    if (months && months !== 0) {
+      return calculateNewDateWithOffset(offsetDate, dateEdge, months, 'month');
+    }
+    if (years && years !== 0) {
+      return calculateNewDateWithOffset(offsetDate, dateEdge, years, 'year');
+    }
+  }
+  return offsetDate;
+};
+
+export const calculateNewDateWithOffset = (
+  offsetDate: Date,
+  dateEdge: Date,
+  offsetValue: number,
+  unit: 'date' | 'month' | 'year',
+): Date => {
+  const newDate = addToDate(offsetDate, offsetValue, unit);
+  const isPositiveOffsetValue = offsetValue > 0;
+  if (isPositiveOffsetValue) {
+    const isMaxDateAfterNewDate = maxDateAndAfter(dateEdge, newDate);
+    return isMaxDateAfterNewDate
+      ? subtractFromDate(dateEdge, offsetValue, unit)
+      : offsetDate;
+  }
+  const isMinDateBeforeNewDate = minDateAndBefore(dateEdge, newDate);
+  return isMinDateBeforeNewDate
+    ? subtractFromDate(dateEdge, offsetValue, unit)
+    : offsetDate;
 };


### PR DESCRIPTION
Hello, This is my attempt to fix the behaviour described in https://github.com/rehookify/datepicker/pull/46

I tried the approach that you, @Feshchenko, mentioned in your comments and used the **offsetDate** in order to achieve the desired behavior without needing to update the disabling logic.

This is an example of what the code does behind the scenes (the same happens in the videos attached below):

Situation 1 - Edge case maxDate:

- Previously, the offsetDate was set to selectedDate but in my case:
   - Initial selectedDate = 20.1.2024
   - maxDate = 13.2024
   - **(new)** offsetDate = 13.1.2024 -> maxDate - 1 month (previously, the offset Date was 20.1.2024 which resulted in a disabled button)
   
Situation 2 - Edge case minDate:
   - initial selectedDate = 20.1.2024
   - minDate = 22.11.2023
   - offsetDate = 20.1.2024 - no change needed - same as the initial value
   -> Now, the user clicks on the previous button, what happens next:
      - selectedDate remains unchanged
      - minDate remains unchanged
      -  **(new)** offsetDate = 22.12.2023 -> minDate + 1 month (previously, the offset Date would be set to 20.12.2023 which resulted in a disabled button as 20.12.2023 - 1 month is less than minDate 22.11.2023)


I'm also attaching the before and after showcases

Before:
https://github.com/rehookify/datepicker/assets/17575434/2b4209a9-072c-4679-a7f5-99692b6643ea

After:
https://github.com/rehookify/datepicker/assets/17575434/f8a20c7f-8153-40e9-9b94-0e70fc558820

Props setup from the video:
mode: 'single'
maxDate: 13.2.2024
minDate: 22.11.2024
selectedDates: [20.1.2024]

fyi @marianadrozdova @ebartunek



